### PR TITLE
Backwards compatibility for uglifierJS (no ES6 yet)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function objectWithoutProperties (object, properties) {
 
   var obj = {}
   var keys = Object.keys(object)
-  keys.forEach((key) => {
+  keys.forEach(function(key){
     if (!~properties.indexOf(key)) {
       obj[key] = object[key]
     }


### PR DESCRIPTION
This would object-without-properties to be used with UglifierJS (which doesn't yet support ES6) if you are interested in that.

```
$ uglifyjs index.js
Parse error at index.js:6,22
Unexpected token: operator (>)
...
```
